### PR TITLE
Allow explicitly concatenating to a single file

### DIFF
--- a/s3_concat/__init__.py
+++ b/s3_concat/__init__.py
@@ -30,7 +30,8 @@ class S3Concat:
                 self.key,
                 part_data,
                 small_parts_threads=small_parts_threads,
-                content_type=self.content_type
+                add_part_number=self.min_file_size is not None,
+                content_type=self.content_type,
             )
             part_keys.append(upload_resp.result_filepath)
 

--- a/s3_concat/multipart_upload_job.py
+++ b/s3_concat/multipart_upload_job.py
@@ -8,6 +8,7 @@ class MultipartUploadJob:
 
     def __init__(self, bucket, result_filepath, data_input,
                  small_parts_threads=1,
+                 add_part_number=True,
                  content_type='application/octet-stream'):
         # threading support comming soon
         self.bucket = bucket
@@ -15,15 +16,18 @@ class MultipartUploadJob:
         self.content_type = content_type
         self.small_parts_threads = small_parts_threads
 
-        if '.' in result_filepath.split('/')[-1]:
-            # If there is a file extention, put the part number before it
-            path_parts = result_filepath.rsplit('.', 1)
-            self.result_filepath = '{}-{}.{}'.format(path_parts[0],
-                                                     self.part_number,
-                                                     path_parts[1])
+        if add_part_number:
+            if '.' in result_filepath.split('/')[-1]:
+                # If there is a file extention, put the part number before it
+                path_parts = result_filepath.rsplit('.', 1)
+                self.result_filepath = '{}-{}.{}'.format(path_parts[0],
+                                                         self.part_number,
+                                                         path_parts[1])
+            else:
+                self.result_filepath = '{}-{}'.format(result_filepath,
+                                                      self.part_number)
         else:
-            self.result_filepath = '{}-{}'.format(result_filepath,
-                                                  self.part_number)
+            self.result_filepath = result_filepath
 
         # s3 cannot be a class var because the Pool cannot pickle it
         s3 = _create_s3_client()

--- a/s3_concat/utils.py
+++ b/s3_concat/utils.py
@@ -71,7 +71,7 @@ def _chunk_by_size(file_list, min_file_size):
     for p in file_list:
         current_size += p[1]
         current_list.append(p)
-        if current_size > min_file_size:
+        if min_file_size is not None and current_size > min_file_size:
             grouped_list.append((current_index, current_list))
             current_list = []
             current_size = 0
@@ -96,6 +96,8 @@ def _convert_to_bytes(value):
     Raises:
         ValueError -- if the input value is not a valid type to convert
     """
+    if value is None:
+        return None
     value = value.strip()
     sizes = {'KB': 1024,
              'MB': 1024**2,


### PR DESCRIPTION
Sometimes I'd like to concatenate S3 files into a single file - instead of breaking up based on rough part sizes.  

This implements that idea, by adding a special case when `min_file_size` is None.