### PR TITLE
Allow caller to specify which boto3 Session to use

### DIFF
--- a/s3_concat/__init__.py
+++ b/s3_concat/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import boto3
 
 from .utils import _create_s3_client, _convert_to_bytes, _chunk_by_size
 from .multipart_upload_job import MultipartUploadJob
@@ -9,13 +10,14 @@ logger = logging.getLogger(__name__)
 class S3Concat:
 
     def __init__(self, bucket, key, min_file_size,
-                 content_type='application/octet-stream'):
+                 content_type='application/octet-stream',
+                 session=boto3.session.Session()):
         self.bucket = bucket
         self.key = key
         self.min_file_size = _convert_to_bytes(min_file_size)
         self.content_type = content_type
         self.all_files = []
-        self.s3 = _create_s3_client()
+        self.s3 = _create_s3_client(session)
 
     def concat(self, small_parts_threads=1):
 
@@ -29,6 +31,7 @@ class S3Concat:
                 self.bucket,
                 self.key,
                 part_data,
+                self.s3,
                 small_parts_threads=small_parts_threads,
                 add_part_number=self.min_file_size is not None,
                 content_type=self.content_type,

--- a/s3_concat/multipart_upload_job.py
+++ b/s3_concat/multipart_upload_job.py
@@ -1,5 +1,5 @@
 import logging
-from .utils import _create_s3_client, _threads, _chunk_by_size, MIN_S3_SIZE
+from .utils import _threads, _chunk_by_size, MIN_S3_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -7,9 +7,11 @@ logger = logging.getLogger(__name__)
 class MultipartUploadJob:
 
     def __init__(self, bucket, result_filepath, data_input,
+                 s3,
                  small_parts_threads=1,
                  add_part_number=True,
                  content_type='application/octet-stream'):
+        # s3 cannot be a class var because the Pool cannot pickle it
         # threading support comming soon
         self.bucket = bucket
         self.part_number, self.parts_list = data_input
@@ -29,8 +31,6 @@ class MultipartUploadJob:
         else:
             self.result_filepath = result_filepath
 
-        # s3 cannot be a class var because the Pool cannot pickle it
-        s3 = _create_s3_client()
         if len(self.parts_list) == 1:
             # Perform a simple S3 copy since there is just a single file
             source_file = "{}/{}".format(self.bucket, self.parts_list[0][0])

--- a/s3_concat/utils.py
+++ b/s3_concat/utils.py
@@ -49,8 +49,7 @@ def _threads(num_threads, data, callback, *args, **kwargs):
     return item_list
 
 
-def _create_s3_client():
-    session = boto3.session.Session()
+def _create_s3_client(session):
     return session.client('s3')
 
 


### PR DESCRIPTION
Hi!

I'm using s3-concat from another library.  The other library accepts in boto3 Session objects to specify how to access S3 (which may differ from the AWS credentials hanging around as environment variables or as the default creds in `~/.aws`, depending on where it's run from).  

This should allow the Session to be specified (but still keeps the default boto3 session lookup if that parameter is not specified).