### PR TITLE
Improve quotes handling in etags

### DIFF
--- a/s3_concat/multipart_upload_job.py
+++ b/s3_concat/multipart_upload_job.py
@@ -80,8 +80,9 @@ class MultipartUploadJob:
                                                             source_part)
             logger.debug("{}, got response: {}".format(msg, resp))
 
-            parts_mapping.append({'ETag': resp['CopyPartResult']['ETag'][1:-1],
-                                  'PartNumber': part_num})
+            #ceph doesn't return quoted etags
+            etag=resp['CopyPartResult']['ETag'].replace("'","").replace("\"","")
+            parts_mapping.append({'ETag': etag, 'PartNumber': part_num})
 
         # assemble parts too small for direct S3 copy by downloading them,
         # combining them, and then reuploading them as the last part of the
@@ -124,8 +125,9 @@ class MultipartUploadJob:
                 logger.debug("{}, got response: {}".format(msg, resp))
 
                 last_part = None
-
-                return {'ETag': resp['ETag'][1:-1],
+                # Handles both quoted and unquoted etags
+                etag=resp['ETag'].replace("'","").replace("\"","")
+                return {'ETag': etag,
                         'PartNumber': part_num}
             return {}
 


### PR DESCRIPTION
Ceph provides s3 compatible object gateway where we observed an issue with etag not being quoted. Instead of stripping first and last we are removing quotes to make it generic and hopefully working with any s3 compatible storage