### PR TITLE
Using ThreadPoolExecutor to avoid memory leak

### DIFF
--- a/s3_concat/__init__.py
+++ b/s3_concat/__init__.py
@@ -12,13 +12,14 @@ class S3Concat:
     def __init__(self, bucket, key, min_file_size,
                  content_type='application/octet-stream',
                  session=boto3.session.Session(),
-                 s3_client_kwargs=None):
+                 s3_client_kwargs=None,
+                 s3_client=None):
         self.bucket = bucket
         self.key = key
         self.min_file_size = _convert_to_bytes(min_file_size)
         self.content_type = content_type
         self.all_files = []
-        self.s3 = _create_s3_client(session, s3_client_kwargs=s3_client_kwargs)
+        self.s3 = s3_client or _create_s3_client(session, s3_client_kwargs=s3_client_kwargs)
 
     def concat(self, small_parts_threads=1):
 


### PR DESCRIPTION
see https://github.com/xtream1101/s3-concat/issues/11

There is also now a new constructor argument that mitigates the recreation of s3 clients for every usage of this class, it seems boto3 does not clean them up correctly once they are not used anymore.