### PR TITLE
Use put when combining small files. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 setup(
     name='s3-concat',
     packages=['s3_concat'],
-    version='0.2.3',
+    version='0.2.4',
     description='Concat files in s3',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The documented minimum for multipart upload is 5MB, if the total size of all the files to upload in a batch is less than 5MB then use a regular S3 put instead.

I realize this adds some duplication but wanted to open the PR to get feedback. If this is something that would be useful to the project, let me know and I'll try to clean it up some more.